### PR TITLE
add message button to legacy fulfillment, handle add note error on order

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -100,9 +100,10 @@ export async function createServer(
       });
       res.status(200).send(data);
     } catch (e) {
-      res
-        .status(500)
-        .send({ message: 'There was an error fulfilling the order' });
+      console.log(e.message);
+      res.status(500).send({
+        message: `There was an error fulfilling the order: ${e.message}`,
+      });
     }
   });
 
@@ -120,6 +121,7 @@ export async function createServer(
       });
       res.status(200).send(data);
     } catch (e) {
+      console.log(e);
       res
         .status(500)
         .send({ message: 'There was an error updating the order' });


### PR DESCRIPTION
This are the changes i made this afternoon after our pairing session this morning. 
It adds the message button to the table.
Checks to make sure there is a message before making the 2nd api call
Handles error if the API call fails -> This part needs some work its pretty messy / confusing.